### PR TITLE
Pass the shell name as the argument to **env-init

### DIFF
--- a/libexec/anyenv-init
+++ b/libexec/anyenv-init
@@ -99,7 +99,7 @@ for env in $(anyenv-envs); do
   ANYENV_ADD_PATH="${ENV_ROOT}/bin:${ANYENV_ADD_PATH}"
   echo "export ${ENV_ROOT_VALUE}=\"${ENV_ROOT}\""
   export ${ENV_ROOT_VALUE}="${ENV_ROOT}"
-  echo "$(${ENV_ROOT}/bin/${env} init -)"
+  echo "$(${ENV_ROOT}/bin/${env} init - ${shell})"
 done
 
 if ! [ -z "$ANYENV_ADD_PATH" ]; then


### PR DESCRIPTION
This request adds "${shell}" as an argument to the initialization commands for *_env.
I guess it is important to take consistency of the shell type between anyenv and any other *_env.
Please confirm it useful or not.
Thank you for reading my poor English.
