### PR TITLE
add ${ENV_ROOT}/shims

### DIFF
--- a/libexec/anyenv-init
+++ b/libexec/anyenv-init
@@ -96,7 +96,7 @@ ANYENV_ADD_PATH=""
 for env in $(anyenv-envs); do
   ENV_ROOT_VALUE=$(echo ${env}_ROOT | tr "[a-z]" "[A-Z]")
   ENV_ROOT="${ANYENV_ROOT}/envs/${env}"
-  ANYENV_ADD_PATH="${ENV_ROOT}/bin:${ANYENV_ADD_PATH}"
+  ANYENV_ADD_PATH="${ENV_ROOT}/bin:${ENV_ROOT}/shims:${ANYENV_ADD_PATH}"
   echo "export ${ENV_ROOT_VALUE}=\"${ENV_ROOT}\""
   export ${ENV_ROOT_VALUE}="${ENV_ROOT}"
   echo "$(${ENV_ROOT}/bin/${env} init - ${shell})"


### PR DESCRIPTION
When tmux is started, the execution result of the
'$(${ENV_ROOT}/bin/${env} init -)' is 'source
$HOME/.anyenv/envs/plenv/libexec/../completions/plenv.zsh' instead of
export PATH additional shims.
So, is not available *env.

As a result of this commit, it will be read twice the shims, but I do
not care.
e.g.)
$HOME/.anyenv/envs/rbenv/bin
$HOME/.anyenv/envs/rbenv/shims
$HOME/.anyenv/envs/plenv/bin
$HOME/.anyenv/envs/plenv/shims
$HOME/.anyenv/envs/rbenv/shims
$HOME/.anyenv/envs/plenv/shims
