### PR TITLE
Add goenv support

### DIFF
--- a/share/anyenv-install/goenv
+++ b/share/anyenv-install/goenv
@@ -1,0 +1,1 @@
+install_env "https://github.com/wfarr/goenv" "master"


### PR DESCRIPTION
Currently wfarr's goenv-install doesn't support "-l". Directly
supply the version of go works, e.g. "goenv install 1.2.1" will
install the latest stable go. The rest are the same.
