### PR TITLE
change goenv git repository url

### DIFF
--- a/share/anyenv-install/goenv
+++ b/share/anyenv-install/goenv
@@ -1,1 +1,1 @@
-install_env "https://github.com/wfarr/goenv" "master"
+install_env "https://github.com/dataich/goenv.git" "master"


### PR DESCRIPTION
change goenv git repository url from wfarr/goenv to dataich/goenv.
Golang binary download location have been changed, but wfarr/goenv is not maintained.
