### PR TITLE
Change phpenv repository & install php-build

### DIFF
--- a/share/anyenv-install/phpenv
+++ b/share/anyenv-install/phpenv
@@ -1,1 +1,2 @@
-install_env "https://github.com/phpenv/phpenv.git" "dev"
+install_env "https://github.com/laprasdrum/phpenv.git" "master"
+install_plugin "php-build" "https://github.com/CHH/php-build.git" "master"


### PR DESCRIPTION
I changed the phpenv repository and installed php-build.

In [phpenv/phpenv](https://github.com/phpenv/phpenv), there were no available versions. The [Issue #38](https://github.com/phpenv/phpenv/issues/38#issuecomment-31464333) seems not fixed yet. 

``` bash
$ phpenv install -l
phpenv v0.0.4-dev

```

I found an another phpenv respository that works well. Thank you!
