### PR TITLE
Fix urls and add phpenv-composer plugin

### DIFF
--- a/share/anyenv-install/phpenv
+++ b/share/anyenv-install/phpenv
@@ -1,2 +1,3 @@
-install_env "https://github.com/laprasdrum/phpenv.git" "master"
-install_plugin "php-build" "https://github.com/CHH/php-build.git" "master"
+install_env "https://github.com/madumlao/phpenv.git" "master"
+install_plugin "php-build" "https://github.com/php-build/php-build.git" "master"
+install_plugin "phpenv-composer" https://github.com/ngyuki/phpenv-composer "master"


### PR DESCRIPTION
php-build URL was changed.
And, https://github.com/laprasdrum/phpenv seems abandoned...

So, I fix php-build URL and change phpenv repo.
Moreover, add phpenv-composer plugin.  This plugin is useful for composer, the modern PHP package manager.
