### PR TITLE
Workaround for erlenv when invoking to `anyenv versions`

### DIFF
--- a/libexec/anyenv-versions
+++ b/libexec/anyenv-versions
@@ -9,5 +9,9 @@ set -e
 
 for env in $(anyenv-envs); do
   echo "$env:"
-  echo "$($env versions)"
+  if [ "$env" = "erlenv" ]; then
+    echo "$($env releases)"
+  else
+    echo "$($env versions)"
+  fi
 done


### PR DESCRIPTION
erlenv uses `releases` subcommand instead of `versions` . I always looks following error.

```
erlenv:
erlenv: no such command `versions'
```
