### PR TITLE
Change the goenv repository url

### DIFF
--- a/share/anyenv-install/goenv
+++ b/share/anyenv-install/goenv
@@ -1,1 +1,1 @@
-install_env "https://github.com/dataich/goenv.git" "master"
+install_env "https://github.com/kaneshin/goenv.git" "master"


### PR DESCRIPTION
Hello there.

I'd prefer the repository of goenv because this is maintained by its owner.

Thanks!
