### PR TITLE
New install/uninstall/update commands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -33,6 +33,77 @@ This is a simple wrapper for [rbenv](https://github.com/sstephenson/rbenv) style
     rbenv: 1.9.3-p327 (set by /home/riywo/.anyenv/envs/rbenv/version)
     goenv: 1.2.2
 
+## TARGET
+
+Anyenv installs/updates/uninstalls targets. A target can be an env or plugin.
+
+The basic form of target is `ENV/PLUGIN`, which means "PLUGIN of ENV". There is also a special case: for `ENV/ENV`, it means the ENV itself. For instance, `rbenv/rbenv` means `rbenv`, **NOT** a plugin named `rbenv`.
+
+You can also use the short form for a target by the following rules:
+
+TARGET (short form) | TARGET (full form) | ENV     | PLUGIN
+------------------- | ------------------ | ------- | -----------
+foo/bar             | foo/bar            | foo     | bar
+foo/foo-bar         | foo/foo-bar        | foo     | foo-bar
+foo/baz-bar         | foo/baz-bar        | foo     | baz-bar
+foo/foo             | foo/foo            | foo     | foo
+foo                 | foo/foo            | foo     | foo
+foo-bar             | foo/foo-bar        | foo     | foo-bar
+foo-bar-baz         | foo/foo-bar-baz    | foo     | foo-bar-baz
+foo/                | foo/foo            | foo     | foo
+/bar                | bar/bar            | bar     | bar
+/foo-bar            | foo/foo-bar        | foo     | foo-bar
+foo-bar/            | foo-bar/foo-bar    | foo-bar | foo-bar
+
+For example:
+
+TARGET (short form) | TARGET (full form) | ENV   | PLUGIN
+------------------- | ------------------ | ----- | ----------
+rbenv/rbenv-each    | rbenv/rbenv-each   | rbenv | rbenv-each
+rbenv               | rbenv/rbenv        | rbenv | rbenv
+rbenv-each          | rbenv/rbenv-each   | rbenv | rbenv-each
+rbenv/ruby-build    | rbenv/ruby-build   | rbenv | ruby-build
+ruby-build          | ruby/ruby-build    | ruby  | ruby-build
+
+Remember, `rbenv/rbenv` means the env `rbenv`, **NOT** a plugin named `rbenv`.
+
+Usage example:
+
+```
+$ anyenv install rbenv
+$ anyenv install rbenv-each
+$ anyenv install rbenv/rbenv-each
+$ anyenv install rbenv/ruby-build
+$ anyenv install rbenv rbenv-each rbenv/ruby-build
+$ anyenv update pyenv rbenv-each rbenv/ruby-build
+$ anyenv uninstall pyenv rbenv-each rbenv/ruby-build
+```
+
+### INSTALL TARGET
+
+When installing a target, anyenv will check the source url in the file `SOURCE_DIR/ENV/PLUGIN`. Anyenv will try `SOURCE_DIR` in this order:
+
+  - `$XDG_CONFIG_HOME/anyenv/sources` (default: `$HOME/.config/anyenv/sources`)
+  - `$ANYENV_ROOT/share/anyenv/sources`
+
+The source is the git url downloaded by anyenv. If you want to use a branch other than the default branch, put
+
+```
+<GIT_URL> <GIT_REF>
+```
+
+into the source file.
+
+If the source file does not exist, anyenv will try `https://github.com/ENV/PLUGIN.git` with the default branch.
+
+You can also override the url and default branch in the argument, using `TARGET[=URL][@REF]`.  For example:
+
+```
+$ anyenv install rbenv=https://github.com/foo/bar.git
+$ anyenv install rbenv@baz
+$ anyenv install rbenv=https://github.com/foo/bar.git@baz
+```
+
 ## PLUGINS
 
 - [znz/anyenv-update](https://github.com/znz/anyenv-update)

--- a/libexec/anyenv-install
+++ b/libexec/anyenv-install
@@ -1,85 +1,241 @@
 #!/usr/bin/env bash
 #
-# Summary: Install a **env
+# Summary: Install ENVs or plugins
 #
-# Usage: anyenv install [-f|--force] <**env>
-#        anyenv install -l|--list
+# Usage: anyenv i [-f|--force] TARGET[=URL][@REF] [TARGET[=URL][@REF] ...]
 #
-#   -l/--list          List all available **envs
-#   -f/--force         Install even if the **env appears to be installed already
+#   -f/--force         Install even if the target appears to be installed already
+#   -v/--verbose       Run verbosely
 #   -s/--skip-existing Skip if the version appears to be installed already
 #
 set -e
-[ -n "$ANYENV_DEBUG" ] && set -x
+[ -z "$ANYENV_DEBUG" ] || set -x
 
-list_definitions() {
-  { for definition in "${ANYENV_ROOT}/share/anyenv-install/"*; do
-      echo "${definition##*/}"
-    done
-  } | sort
-}
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
 
-install_env() {
-  local package_name="$DEFINITION"
-  local git_url="$1"
-  local git_ref="$2"
-
-  mkdir -p "$BUILD_DIR"
-  pushd "$BUILD_DIR"
-  fetch_git "${package_name}" "${git_url}" "${git_ref}"
-  popd
-
-  if [ -d "$PREFIX" ]; then
-    if [ -d "${PREFIX}/versions" ]; then
-      mv "${PREFIX}/versions" "${BUILD_DIR}/${ENV_NAME}/versions"
-    fi
-    if [ -f "${PREFIX}/version" ]; then
-      mv "${PREFIX}/version" "${BUILD_DIR}/${ENV_NAME}/version"
-    fi
-    mv "$PREFIX" "${BUILD_DIR}.prev"
-  fi
-  mv "${BUILD_DIR}/${ENV_NAME}" "$PREFIX"
-}
-
-install_plugin() {
-  local package_name="$1"
-  local git_url="$2"
-  local git_ref="$3"
-
-  mkdir -p "${PREFIX}/plugins"
-  pushd "${PREFIX}/plugins"
-  fetch_git "${package_name}" "${git_url}" "${git_ref}"
-  popd
-}
-
-fetch_git() {
-  local package_name="$1"
-  local git_url="$2"
-  local git_ref="$3"
-
-  echo "Cloning ${git_url}..."
-
-  if type git &>/dev/null; then
-    git clone --branch "$git_ref" "$git_url" "${package_name}"
-  else
-    echo "error: please install \`git\` and try again"
-    exit 1
-  fi
-}
+# Provide anyenv completions
+if [ "$1" = "--complete" ]; then
+  echo --force
+  echo --skip-existing
+  exit
+fi
 
 usage() {
-  # We can remove the sed fallback once rbenv 0.4.0 is widely available.
-  anyenv-help install 2>/dev/null || sed -ne '/^#/!q;s/.//;s/.//;1,4d;p' < "$0"
+  anyenv-help i 2>/dev/null
   [ -z "$1" ] || exit "$1"
 }
 
-definitions() {
-  local query="$1"
-  list_definitions | grep -F "$query" || true
+set_env_and_plugin() {
+  local target
+  target="$1"
+
+  case "$target" in
+  /*-*)
+    PLUGIN="${target#/}"
+    ENV="${PLUGIN%%-*}"
+    ;;
+  /*)
+    PLUGIN="${target#/}"
+    ENV="${PLUGIN}"
+    ;;
+  */)
+    ENV="${target%/}"
+    PLUGIN="${ENV}"
+    ;;
+  */*)
+    ENV="${target%/*}"
+    PLUGIN="${target#*/}"
+    ;;
+  *-*)
+    ENV="${target%%-*}"
+    PLUGIN="${target}"
+    ;;
+  *)
+    ENV="${target}"
+    PLUGIN="${target}"
+    ;;
+  esac
 }
 
-indent() {
-  sed 's/^/  /'
+set_target_dir() {
+  if [ "$ENV" = anyenv ]; then
+    ENV_DIR="$ANYENV_ROOT"
+  else
+    ENV_DIR="${ANYENV_ROOT}/envs/${ENV}"
+  fi
+
+  if [ "$ENV" = "$PLUGIN" ]; then
+    TARGET_DIR="$ENV_DIR"
+  else
+    TARGET_DIR="${ENV_DIR}/plugins/${PLUGIN}"
+  fi
+}
+
+set_install_type() {
+  INSTALL_TYPE=install
+  if [ -d "$TARGET_DIR" ]; then
+    if [ -n "$SKIP_EXISTING" ]; then
+      INSTALL_TYPE=skip
+    elif [ -n "$FORCE" ]; then
+      INSTALL_TYPE=reinstall
+    else
+      echo "anyenv: ${TARGET_DIR} already exists"
+      echo "Reinstallation keeps versions directories"
+      read -p "continue with installation? (y/N) "
+
+      case "$REPLY" in
+      y* | Y* ) INSTALL_TYPE=reinstall ;;
+      * ) INSTALL_TYPE=skip ;;
+      esac
+    fi
+  fi
+}
+
+fetch_git() {
+  if [ -n "$GIT_REF" ]; then
+    git clone --branch "$GIT_REF" "$GIT_URL" "$BUILD_DIR"
+  else
+    git clone "$GIT_URL" "$BUILD_DIR"
+  fi
+}
+
+remove_previous_env() {
+  mv "${TARGET_DIR}/versions" "${BUILD_DIR}/versions"
+  mv "${TARGET_DIR}/version" "${BUILD_DIR}/version"
+  mv "${TARGET_DIR}" "${TARGET_DIR}.prev"
+}
+
+remove_previous_plugin() {
+  # No need to backup plugin. Just remove it.
+  rm -rf "${TARGET_DIR}"
+}
+
+remove_before_install() {
+  if [ "$ENV" = "$PLUGIN" ]; then
+    remove_previous_env
+  else
+    remove_previous_plugin
+  fi
+}
+
+target_name() {
+  if [ "$ENV" = "$PLUGIN" ]; then
+    echo "$ENV"
+  else
+    echo "${ENV}/${PLUGIN}"
+  fi
+}
+
+print_horizontal_separator() {
+  if [ -n "$VERBOSE" ]; then
+    echo
+  fi
+}
+
+install_from_git() {
+  if [ "$INSTALL_TYPE" != skip ]; then
+    if [ -n "$VERBOSE" ]; then
+      if [ -n "$GIT_REF" ]; then
+        echo "Installing '$(target_name)' from '${GIT_URL}@${GIT_REF}'..."
+      else
+        echo "Installing '$(target_name)' from '${GIT_URL}'..."
+      fi
+    fi
+
+    BUILD_ROOT="$(mktemp -d)"
+    BUILD_DIR="${BUILD_ROOT}/$PLUGIN"
+
+    fetch_git
+
+    if [ "$INSTALL_TYPE" = reinstall ]; then
+      remove_before_install
+    fi
+
+    local target_parent_dir
+    target_parent_dir="$(dirname $TARGET_DIR)"
+    [ -d "$target_parent_dir" ] || mkdir -p "$target_parent_dir"
+    mv "$BUILD_DIR" "$TARGET_DIR"
+
+    rm -rf "$BUILD_ROOT"
+
+    print_horizontal_separator
+  fi
+}
+
+read_source() {
+  local src_prefix src
+
+  SRC_URL=""
+  SRC_REF=""
+
+  for src_prefix in "${XDG_CONFIG_HOME}/anyenv/sources" "${ANYENV_ROOT}/share/anyenv/sources"; do
+    src="${src_prefix}/${ENV}/${PLUGIN}"
+    if [ -f "$src" ]; then
+      read SRC_URL SRC_REF < "$src"
+      break
+    fi
+  done
+}
+
+set_repo_url_and_ref() {
+  if [ -n "$ARG_URL" ]; then
+    GIT_URL="$ARG_URL"
+    GIT_REF="$ARG_REF"
+  elif [ -n "$ARG_REF" ]; then
+    GIT_URL="https://github.com/${ENV}/${PLUGIN}.git"
+    GIT_REF="$ARG_REF"
+  else
+    read_source
+    if [ -n "$SRC_URL" ]; then
+      GIT_URL="$SRC_URL"
+      GIT_REF="$SRC_REF"
+    else
+      GIT_URL="https://github.com/${ENV}/${PLUGIN}.git"
+      GIT_REF=""
+    fi
+  fi
+}
+
+install_target() {
+  local target
+
+  target="${1}"
+  ARG_URL="${1}"
+  ARG_REF="${1}"
+
+  target="${target%%@*}"
+  target="${target%%=*}"
+  ARG_URL="${ARG_URL%%@*}"  # remove @-part first in order to avoid the case of `a@b=c`
+  ARG_URL="${ARG_URL##*=}"
+  ARG_REF="${ARG_REF##*@}"
+
+  if [ "$ARG_URL" = "$target" ]; then
+    ARG_URL=
+  fi
+  if [ "$ARG_REF" = "$1" ]; then
+    ARG_REF=
+  fi
+
+  set_env_and_plugin "$target"
+
+  set_repo_url_and_ref
+
+  if [ "$ENV" = anyenv ] && [ "$ENV" = "$PLUGIN" ]; then
+    echo "anyenv is already installed." >&2
+    return
+  fi
+
+  set_target_dir
+
+  if [ "$ENV" != "$PLUGIN" ] && [ ! -d "$ENV_DIR" ]; then
+    echo "anyenv: unable to install \`$(target_name)'. \`${ENV}' not installed." >&2
+    return
+  fi
+
+  set_install_type
+
+  install_from_git
+
 }
 
 parse_options() {
@@ -105,32 +261,13 @@ parse_options() {
   done
 }
 
-
-unset FORCE
-unset SKIP_EXISTING
-
-# Provide anyenv completions
-if [ "$1" = "--complete" ]; then
-  list_definitions
-  exit 0
-fi
-
-if [ -z "$ANYENV_ROOT" ]; then
-  ANYENV_ROOT="${HOME}/.anyenv"
-fi
-
 parse_options "$@"
 for option in "${OPTIONS[@]}"; do
   case "$option" in
   "h" | "help" )
     usage 0
     ;;
-  "l" | "list" )
-    echo "Available **envs:"
-    definitions | indent
-    exit
-    ;;
-  "f" | "force" )
+  "f" | "force")
     FORCE=true
     ;;
   "s" | "skip-existing" )
@@ -145,77 +282,6 @@ for option in "${OPTIONS[@]}"; do
   esac
 done
 
-unset ENV_NAME
-ANYENV_ENVS_ROOT="${ANYENV_ROOT}/envs"
-
-# The first argument contains the definition to install.
-# Show usage instructions if the definition is not specified.
-DEFINITION="${ARGUMENTS[0]}"
-[ -n "$DEFINITION" ] || usage 1
-
-# Set ENV_NAME from $DEFINITION, if it is not already set. Then
-# compute the installation prefix.
-[ -n "$ENV_NAME" ] || ENV_NAME="${DEFINITION##*/}"
-PREFIX="${ANYENV_ENVS_ROOT}/${ENV_NAME}"
-
-[ -d "${PREFIX}" ] && PREFIX_EXISTS=1
-
-
-BUILTIN_DEFINITION_PATH="${ANYENV_ROOT}/share/anyenv-install/${DEFINITION}"
-if [ -e "$BUILTIN_DEFINITION_PATH" ]; then
-  DEFINITION_PATH="$BUILTIN_DEFINITION_PATH"
-else
-  echo "anyenv-install: definition not found: ${DEFINITION}"
-  exit 2
-fi
-
-# If the installation prefix exists, prompt for confirmation unless
-# the --force option was specified.
-if [ -d "${PREFIX}/bin" ]; then
-  if [ -z "$FORCE" ] && [ -z "$SKIP_EXISTING" ]; then
-    echo "anyenv: $PREFIX already exists"
-    echo "Reinstallation keeps versions directories"
-    read -p "continue with installation? (y/N) "
-
-    case "$REPLY" in
-    y* | Y* ) ;;
-    * ) exit 1 ;;
-    esac
-  elif [ -n "$SKIP_EXISTING" ]; then
-    # Since we know the **env version is already installed, and are opting to
-    # not force installation of existing versions, we just `exit 0` here to
-    # leave things happy
-    exit 0
-  fi
-fi
-
-# Plan cleanup on unsuccessful installation.
-cleanup() {
-  [ -z "${PREFIX_EXISTS}" ] && rm -rf "$PREFIX"
-}
-
-trap cleanup SIGINT
-
-if [ -z "$TMPDIR" ]; then
-  TMP="/tmp"
-else
-  TMP="${TMPDIR%/}"
-fi
-
-SEED="$(date "+%Y%m%d%H%M%S").$$"
-CWD="$(pwd)"
-BUILD_DIR="${TMP}/${ENV_NAME}.${SEED}"
-
-STATUS=0
-source "$DEFINITION_PATH" || STATUS="$?"
-
-if [ "$STATUS" == "0" ]; then
-  echo ""
-  echo "Install $ENV_NAME succeeded!"
-  echo "Please reload your profile (exec \$SHELL -l) or open a new session."
-else
-  echo "Install $ENV_NAME failed"
-  cleanup
-fi
-
-exit "$STATUS"
+for arg in "${ARGUMENTS[@]}"; do
+  install_target "$arg"
+done

--- a/libexec/anyenv-update
+++ b/libexec/anyenv-update
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 #
-# Summary: Uninstall ENVs or plugins
+# Summary: Update ENVs or plugins
 #
-# Usage: anyenv rm [-f|--force] TARGET [TARGET...]
+# Usage: anyenv u [-f|--force] [--without-plugin] [TARGET...]
 #
-#   -f/--force   Attempt to remove the specified TARGET without prompting for
-#                confirmation. If the TARGET does not exist, do not display an
-#                error message.
-#   -v/--verbose Run verbosely
+#   -f/--force       Force update
+#   -v/--verbose     Run verbosely
+#   --without-plugin Update ENVs, but not update plugin of each ENVs
 #
 # See `anyenv envs` for a complete list of installed envs.
 #
@@ -17,11 +16,13 @@ set -e
 # Provide anyenv completions
 if [ "$1" = "--complete" ]; then
   echo --force
+  echo --without-plugin
+  echo anyenv
   exec anyenv envs --bare
 fi
 
 usage() {
-  anyenv-help rm 2>/dev/null
+  anyenv-help u 2>/dev/null
   [ -z "$1" ] || exit "$1"
 }
 
@@ -46,6 +47,10 @@ parse_options () {
       ARGUMENTS[${#ARGUMENTS[*]}]="$arg"
     fi
   done
+}
+
+get_allenvs() {
+  echo "anyenv $(anyenv-envs | tr '\n' ' ')"
 }
 
 set_env_and_plugin() {
@@ -94,6 +99,10 @@ set_target_dir() {
   fi
 }
 
+print_use_forceopt() {
+  echo "Failed to update '$1'. Use 'force' option." >&2
+}
+
 target_name() {
   if [ "$ENV" = "$PLUGIN" ]; then
     echo "$ENV"
@@ -108,48 +117,66 @@ print_horizontal_separator() {
   fi
 }
 
-remove_target_dir() {
-  local should_remove
-  should_remove=
-
-  if [ -d "$TARGET_DIR" ]; then
-    if [ -z "$FORCE" ]; then
-      read -p "anyenv: Uninstall $(target_name) ? "
-      case "$REPLY" in
-      y* | Y* ) should_remove=true ;;
-      * ) should_remove= ;;
-      esac
+update_git() {
+  if [ -d "${TARGET_DIR}/.git" ]; then
+    if [ -n "$VERBOSE" ]; then
+      echo "Updating '$(target_name)'..."
     fi
 
-    if [ -n "$FORCE" ] || [ -n "$should_remove" ]; then
-      if [ -n "$VERBOSE" ]; then
-        echo "Uninstalling '$(target_name)'..."
+    # Check if current branch has tracking branch.
+    if git -C "$TARGET_DIR" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+      if [ -n "$FORCE" ]; then
+        git -C "$TARGET_DIR" pull --force --ff --autostash
+      else
+        git -C "$TARGET_DIR" pull --force --ff-only || print_use_forceopt "$(target_name)"
       fi
-      rm -rf "$TARGET_DIR"
+    fi
+  elif [ -d "${TARGET_DIR}" ]; then
+    if [ -n "$VERBOSE" ]; then
+      echo "Skipping '$(target_name)'; not git repo"
     fi
   else
-    if [ -z "$FORCE" ]; then
-      echo "anyenv: \`$(target_name)' not installed" >&2
-    fi
+    echo "anyenv: target '$(target_name)' does not exist" >&2
   fi
 
   print_horizontal_separator
 }
 
-uninstall_target() {
+update_env() {
+  update_git
+}
+
+update_plugin() {
+  update_git
+}
+
+update_plugins() {
+  shopt -s nullglob
+  local plugin_dir env
+  plugin_dir="${TARGET_DIR}/plugins"
+  env="$ENV"
+  for plugin in $plugin_dir/*; do
+    update_target "${env}/$(basename $plugin)"
+  done
+  shopt -u nullglob
+}
+
+update_target() {
   local target
   target="$1"
 
   set_env_and_plugin "$target"
 
-  if [ "$ENV" = anyenv ] && [ "$ENV" = "$PLUGIN" ]; then
-    echo "Unable to uninstall anyenv." >&2
-    return
-  fi
-
   set_target_dir
 
-  remove_target_dir
+  if [ "$ENV" = "$PLUGIN" ]; then
+    update_env
+    if [ -z "$WITHOUT_PLUGIN" ]; then
+      update_plugins
+    fi
+  else
+    update_plugin
+  fi
 
 }
 
@@ -165,6 +192,9 @@ for option in "${OPTIONS[@]}"; do
   "v" | "verbose" )
     VERBOSE=true
     ;;
+  "without-plugin" )
+    WITHOUT_PLUGIN=true
+    ;;
   * )
     echo "no such option: ${option}" >&2
     echo
@@ -173,6 +203,11 @@ for option in "${OPTIONS[@]}"; do
   esac
 done
 
-for arg in "${ARGUMENTS[@]}"; do
-  uninstall_target "$arg"
+TARGETS=("${ARGUMENTS[@]}")
+if [ "${#ARGUMENTS[@]}" -eq 0 ]; then
+  TARGETS=($(get_allenvs))
+fi
+
+for arg in "${TARGETS[@]}"; do
+  update_target "$arg"
 done

--- a/share/anyenv-install/Renv
+++ b/share/anyenv-install/Renv
@@ -1,2 +1,0 @@
-install_env "https://github.com/viking/Renv.git" "Renv"
-install_plugin "R-build" "https://github.com/viking/R-build.git" "R-build"

--- a/share/anyenv-install/crenv
+++ b/share/anyenv-install/crenv
@@ -1,2 +1,0 @@
-install_env "https://github.com/pine/crenv.git" "master"
-install_plugin "crystal-build" "https://github.com/pine/crystal-build.git" "master"

--- a/share/anyenv-install/denv
+++ b/share/anyenv-install/denv
@@ -1,1 +1,0 @@
-install_env "https://github.com/repeatedly/denv.git" "master"

--- a/share/anyenv-install/erlenv
+++ b/share/anyenv-install/erlenv
@@ -1,1 +1,0 @@
-install_env "https://github.com/talentdeficit/erlenv.git" "master"

--- a/share/anyenv-install/exenv
+++ b/share/anyenv-install/exenv
@@ -1,2 +1,0 @@
-install_env "https://github.com/exenv/exenv.git" "master"
-install_plugin "elixir-build" "https://github.com/mururu/elixir-build.git" "master"

--- a/share/anyenv-install/goenv
+++ b/share/anyenv-install/goenv
@@ -1,1 +1,0 @@
-install_env "https://github.com/syndbg/goenv.git" "master"

--- a/share/anyenv-install/hsenv
+++ b/share/anyenv-install/hsenv
@@ -1,1 +1,0 @@
-install_env "https://github.com/wereHamster/hsenv.git" "master"

--- a/share/anyenv-install/jenv
+++ b/share/anyenv-install/jenv
@@ -1,1 +1,0 @@
-install_env "https://github.com/gcuisinier/jenv.git" "master"

--- a/share/anyenv-install/luaenv
+++ b/share/anyenv-install/luaenv
@@ -1,2 +1,0 @@
-install_env "https://github.com/cehoffman/luaenv.git" "master"
-install_plugin "lua-build" "https://github.com/cehoffman/lua-build" "master"

--- a/share/anyenv-install/ndenv
+++ b/share/anyenv-install/ndenv
@@ -1,2 +1,0 @@
-install_env "https://github.com/riywo/ndenv.git" "master"
-install_plugin "node-build" "https://github.com/riywo/node-build.git" "master"

--- a/share/anyenv-install/nenv
+++ b/share/anyenv-install/nenv
@@ -1,1 +1,0 @@
-install_env "https://github.com/ryuone/nenv.git" "master"

--- a/share/anyenv-install/nodenv
+++ b/share/anyenv-install/nodenv
@@ -1,4 +1,0 @@
-install_env "https://github.com/nodenv/nodenv.git" "master"
-install_plugin "node-build" "https://github.com/nodenv/node-build.git" "master"
-install_plugin "nodenv-default-packages" "https://github.com/nodenv/nodenv-default-packages.git" "master"
-install_plugin "nodenv-vars" "https://github.com/nodenv/nodenv-vars.git" "master"

--- a/share/anyenv-install/phpenv
+++ b/share/anyenv-install/phpenv
@@ -1,3 +1,0 @@
-install_env "https://github.com/madumlao/phpenv.git" "master"
-install_plugin "php-build" "https://github.com/php-build/php-build.git" "master"
-install_plugin "phpenv-composer" https://github.com/ngyuki/phpenv-composer "master"

--- a/share/anyenv-install/plenv
+++ b/share/anyenv-install/plenv
@@ -1,2 +1,0 @@
-install_env "https://github.com/tokuhirom/plenv.git" "master"
-install_plugin "perl-build" "https://github.com/tokuhirom/Perl-Build.git" "master"

--- a/share/anyenv-install/pyenv
+++ b/share/anyenv-install/pyenv
@@ -1,1 +1,0 @@
-install_env "https://github.com/yyuu/pyenv.git" "master"

--- a/share/anyenv-install/rbenv
+++ b/share/anyenv-install/rbenv
@@ -1,2 +1,0 @@
-install_env "https://github.com/rbenv/rbenv.git" "master"
-install_plugin "ruby-build" "https://github.com/rbenv/ruby-build.git" "master"

--- a/share/anyenv-install/sbtenv
+++ b/share/anyenv-install/sbtenv
@@ -1,1 +1,0 @@
-install_env "https://github.com/sbtenv/sbtenv.git" "master"

--- a/share/anyenv-install/scalaenv
+++ b/share/anyenv-install/scalaenv
@@ -1,1 +1,0 @@
-install_env "https://github.com/scalaenv/scalaenv.git" "master"

--- a/share/anyenv-install/swiftenv
+++ b/share/anyenv-install/swiftenv
@@ -1,1 +1,0 @@
-install_env "https://github.com/kylef/swiftenv.git" "master"

--- a/share/anyenv/sources/Renv/R-build
+++ b/share/anyenv/sources/Renv/R-build
@@ -1,0 +1,1 @@
+https://github.com/viking/R-build.git

--- a/share/anyenv/sources/Renv/Renv
+++ b/share/anyenv/sources/Renv/Renv
@@ -1,0 +1,1 @@
+https://github.com/viking/Renv.git

--- a/share/anyenv/sources/crenv/crenv
+++ b/share/anyenv/sources/crenv/crenv
@@ -1,0 +1,1 @@
+https://github.com/pine/crenv.git

--- a/share/anyenv/sources/crenv/crystal-build
+++ b/share/anyenv/sources/crenv/crystal-build
@@ -1,0 +1,1 @@
+https://github.com/pine/crystal-build.git

--- a/share/anyenv/sources/denv/denv
+++ b/share/anyenv/sources/denv/denv
@@ -1,0 +1,1 @@
+https://github.com/repeatedly/denv.git

--- a/share/anyenv/sources/erlenv/erlenv
+++ b/share/anyenv/sources/erlenv/erlenv
@@ -1,0 +1,1 @@
+https://github.com/talentdeficit/erlenv.git

--- a/share/anyenv/sources/exenv/elixir-build
+++ b/share/anyenv/sources/exenv/elixir-build
@@ -1,0 +1,1 @@
+https://github.com/mururu/elixir-build.git

--- a/share/anyenv/sources/exenv/exenv
+++ b/share/anyenv/sources/exenv/exenv
@@ -1,0 +1,1 @@
+https://github.com/exenv/exenv.git

--- a/share/anyenv/sources/goenv/goenv
+++ b/share/anyenv/sources/goenv/goenv
@@ -1,0 +1,1 @@
+https://github.com/syndbg/goenv.git

--- a/share/anyenv/sources/hsenv/hsenv
+++ b/share/anyenv/sources/hsenv/hsenv
@@ -1,0 +1,1 @@
+https://github.com/wereHamster/hsenv.git

--- a/share/anyenv/sources/jenv/jenv
+++ b/share/anyenv/sources/jenv/jenv
@@ -1,0 +1,1 @@
+https://github.com/gcuisinier/jenv.git

--- a/share/anyenv/sources/luaenv/lua-build
+++ b/share/anyenv/sources/luaenv/lua-build
@@ -1,0 +1,1 @@
+https://github.com/cehoffman/lua-build.git

--- a/share/anyenv/sources/luaenv/luaenv
+++ b/share/anyenv/sources/luaenv/luaenv
@@ -1,0 +1,1 @@
+https://github.com/cehoffman/luaenv.git

--- a/share/anyenv/sources/ndenv/ndenv
+++ b/share/anyenv/sources/ndenv/ndenv
@@ -1,0 +1,1 @@
+https://github.com/riywo/ndenv.git

--- a/share/anyenv/sources/ndenv/node-build
+++ b/share/anyenv/sources/ndenv/node-build
@@ -1,0 +1,1 @@
+https://github.com/riywo/node-build.git

--- a/share/anyenv/sources/nenv/nenv
+++ b/share/anyenv/sources/nenv/nenv
@@ -1,0 +1,1 @@
+https://github.com/ryuone/nenv.git

--- a/share/anyenv/sources/phpenv/php-build
+++ b/share/anyenv/sources/phpenv/php-build
@@ -1,0 +1,1 @@
+https://github.com/php-build/php-build.git

--- a/share/anyenv/sources/phpenv/phpenv
+++ b/share/anyenv/sources/phpenv/phpenv
@@ -1,0 +1,1 @@
+https://github.com/madumlao/phpenv.git

--- a/share/anyenv/sources/phpenv/phpenv-composer
+++ b/share/anyenv/sources/phpenv/phpenv-composer
@@ -1,0 +1,1 @@
+https://github.com/ngyuki/phpenv-composer.git

--- a/share/anyenv/sources/plenv/perl-build
+++ b/share/anyenv/sources/plenv/perl-build
@@ -1,0 +1,1 @@
+https://github.com/tokuhirom/Perl-Build.git

--- a/share/anyenv/sources/plenv/plenv
+++ b/share/anyenv/sources/plenv/plenv
@@ -1,0 +1,1 @@
+https://github.com/tokuhirom/plenv.git

--- a/share/anyenv/sources/plenv/plenv-contrib
+++ b/share/anyenv/sources/plenv/plenv-contrib
@@ -1,0 +1,1 @@
+https://github.com/miyagawa/plenv-contrib.git

--- a/share/anyenv/sources/pyenv/pyenv
+++ b/share/anyenv/sources/pyenv/pyenv
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv.git

--- a/share/anyenv/sources/pyenv/pyenv-alias
+++ b/share/anyenv/sources/pyenv/pyenv-alias
@@ -1,0 +1,1 @@
+https://github.com/s1341/pyenv-alias.git

--- a/share/anyenv/sources/pyenv/pyenv-ccache
+++ b/share/anyenv/sources/pyenv/pyenv-ccache
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-ccache.git

--- a/share/anyenv/sources/pyenv/pyenv-default-packages
+++ b/share/anyenv/sources/pyenv/pyenv-default-packages
@@ -1,0 +1,1 @@
+https://github.com/jawshooah/pyenv-default-packages.git

--- a/share/anyenv/sources/pyenv/pyenv-doctor
+++ b/share/anyenv/sources/pyenv/pyenv-doctor
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-doctor.git

--- a/share/anyenv/sources/pyenv/pyenv-implict
+++ b/share/anyenv/sources/pyenv/pyenv-implict
@@ -1,0 +1,1 @@
+https://github.com/concordusapps/pyenv-implict.git

--- a/share/anyenv/sources/pyenv/pyenv-installer
+++ b/share/anyenv/sources/pyenv/pyenv-installer
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-installer.git

--- a/share/anyenv/sources/pyenv/pyenv-pip-migrate
+++ b/share/anyenv/sources/pyenv/pyenv-pip-migrate
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-pip-migrate.git

--- a/share/anyenv/sources/pyenv/pyenv-pip-rehash
+++ b/share/anyenv/sources/pyenv/pyenv-pip-rehash
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-pip-rehash.git

--- a/share/anyenv/sources/pyenv/pyenv-register
+++ b/share/anyenv/sources/pyenv/pyenv-register
@@ -1,0 +1,1 @@
+https://github.com/doloopwhile/pyenv-register.git

--- a/share/anyenv/sources/pyenv/pyenv-update
+++ b/share/anyenv/sources/pyenv/pyenv-update
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-update.git

--- a/share/anyenv/sources/pyenv/pyenv-version-ext
+++ b/share/anyenv/sources/pyenv/pyenv-version-ext
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-version-ext.git

--- a/share/anyenv/sources/pyenv/pyenv-virtualenv
+++ b/share/anyenv/sources/pyenv/pyenv-virtualenv
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-virtualenv.git

--- a/share/anyenv/sources/pyenv/pyenv-virtualenvwrapper
+++ b/share/anyenv/sources/pyenv/pyenv-virtualenvwrapper
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-virtualenvwrapper.git

--- a/share/anyenv/sources/pyenv/pyenv-which-ext
+++ b/share/anyenv/sources/pyenv/pyenv-which-ext
@@ -1,0 +1,1 @@
+https://github.com/yyuu/pyenv-which-ext.git

--- a/share/anyenv/sources/rbenv/rbenv-aliases
+++ b/share/anyenv/sources/rbenv/rbenv-aliases
@@ -1,0 +1,1 @@
+https://github.com/tpope/rbenv-aliases.git

--- a/share/anyenv/sources/rbenv/rbenv-around-install
+++ b/share/anyenv/sources/rbenv/rbenv-around-install
@@ -1,0 +1,1 @@
+https://github.com/toy/rbenv-around-install.git

--- a/share/anyenv/sources/rbenv/rbenv-bootstrap
+++ b/share/anyenv/sources/rbenv/rbenv-bootstrap
@@ -1,0 +1,1 @@
+https://github.com/fesplugas/rbenv-bootstrap.git

--- a/share/anyenv/sources/rbenv/rbenv-bundle-exec
+++ b/share/anyenv/sources/rbenv/rbenv-bundle-exec
@@ -1,0 +1,1 @@
+https://github.com/maljub01/rbenv-bundle-exec.git

--- a/share/anyenv/sources/rbenv/rbenv-bundler-ruby-version
+++ b/share/anyenv/sources/rbenv/rbenv-bundler-ruby-version
@@ -1,0 +1,1 @@
+https://github.com/aripollak/rbenv-bundler-ruby-version.git

--- a/share/anyenv/sources/rbenv/rbenv-ccache
+++ b/share/anyenv/sources/rbenv/rbenv-ccache
@@ -1,0 +1,1 @@
+https://github.com/yyuu/rbenv-ccache.git

--- a/share/anyenv/sources/rbenv/rbenv-chefdk
+++ b/share/anyenv/sources/rbenv/rbenv-chefdk
@@ -1,0 +1,1 @@
+https://github.com/docwhat/rbenv-chefdk.git

--- a/share/anyenv/sources/rbenv/rbenv-clean
+++ b/share/anyenv/sources/rbenv/rbenv-clean
@@ -1,0 +1,1 @@
+https://github.com/sableloki/rbenv-clean.git

--- a/share/anyenv/sources/rbenv/rbenv-communal-gems
+++ b/share/anyenv/sources/rbenv/rbenv-communal-gems
@@ -1,0 +1,1 @@
+https://github.com/tpope/rbenv-communal-gems.git

--- a/share/anyenv/sources/rbenv/rbenv-ctags
+++ b/share/anyenv/sources/rbenv/rbenv-ctags
@@ -1,0 +1,1 @@
+https://github.com/tpope/rbenv-ctags.git

--- a/share/anyenv/sources/rbenv/rbenv-env
+++ b/share/anyenv/sources/rbenv/rbenv-env
@@ -1,0 +1,1 @@
+https://github.com/ianheggie/rbenv-env.git

--- a/share/anyenv/sources/rbenv/rbenv-gem-update
+++ b/share/anyenv/sources/rbenv/rbenv-gem-update
@@ -1,0 +1,1 @@
+https://github.com/nicknovitski/rbenv-gem-update.git

--- a/share/anyenv/sources/rbenv/rbenv-gemdir
+++ b/share/anyenv/sources/rbenv/rbenv-gemdir
@@ -1,0 +1,1 @@
+https://github.com/bachue/rbenv-gemdir.git

--- a/share/anyenv/sources/rbenv/rbenv-gemset
+++ b/share/anyenv/sources/rbenv/rbenv-gemset
@@ -1,0 +1,1 @@
+https://github.com/jf/rbenv-gemset.git

--- a/share/anyenv/sources/rbenv/rbenv-git
+++ b/share/anyenv/sources/rbenv/rbenv-git
@@ -1,0 +1,1 @@
+https://github.com/znz/rbenv-git.git

--- a/share/anyenv/sources/rbenv/rbenv-install-remote
+++ b/share/anyenv/sources/rbenv/rbenv-install-remote
@@ -1,0 +1,1 @@
+https://github.com/fgrehm/rbenv-install-remote.git

--- a/share/anyenv/sources/rbenv/rbenv-iterate
+++ b/share/anyenv/sources/rbenv/rbenv-iterate
@@ -1,0 +1,1 @@
+https://github.com/phillip-koebbe-fidelity/rbenv-iterate.git

--- a/share/anyenv/sources/rbenv/rbenv-jruby-mode
+++ b/share/anyenv/sources/rbenv/rbenv-jruby-mode
@@ -1,0 +1,1 @@
+https://github.com/toy/rbenv-jruby-mode.git

--- a/share/anyenv/sources/rbenv/rbenv-man
+++ b/share/anyenv/sources/rbenv/rbenv-man
@@ -1,0 +1,1 @@
+https://github.com/mlafeldt/rbenv-man.git

--- a/share/anyenv/sources/rbenv/rbenv-mygemfile
+++ b/share/anyenv/sources/rbenv/rbenv-mygemfile
@@ -1,0 +1,1 @@
+https://github.com/xing/rbenv-mygemfile.git

--- a/share/anyenv/sources/rbenv/rbenv-only
+++ b/share/anyenv/sources/rbenv/rbenv-only
@@ -1,0 +1,1 @@
+https://github.com/Rodreegez/rbenv-only.git

--- a/share/anyenv/sources/rbenv/rbenv-path
+++ b/share/anyenv/sources/rbenv/rbenv-path
@@ -1,0 +1,1 @@
+https://github.com/taqtiqa/rbenv-path.git

--- a/share/anyenv/sources/rbenv/rbenv-plug
+++ b/share/anyenv/sources/rbenv/rbenv-plug
@@ -1,0 +1,1 @@
+https://github.com/znz/rbenv-plug.git

--- a/share/anyenv/sources/rbenv/rbenv-plugin
+++ b/share/anyenv/sources/rbenv/rbenv-plugin
@@ -1,0 +1,1 @@
+https://github.com/taqtiqa/rbenv-plugin.git

--- a/share/anyenv/sources/rbenv/rbenv-rails
+++ b/share/anyenv/sources/rbenv/rbenv-rails
@@ -1,0 +1,1 @@
+https://github.com/alfa-jpn/rbenv-rails.git

--- a/share/anyenv/sources/rbenv/rbenv-sentience
+++ b/share/anyenv/sources/rbenv/rbenv-sentience
@@ -1,0 +1,1 @@
+https://github.com/tpope/rbenv-sentience.git

--- a/share/anyenv/sources/rbenv/rbenv-sudo
+++ b/share/anyenv/sources/rbenv/rbenv-sudo
@@ -1,0 +1,1 @@
+https://github.com/dcarley/rbenv-sudo.git

--- a/share/anyenv/sources/rbenv/rbenv-update
+++ b/share/anyenv/sources/rbenv/rbenv-update
@@ -1,0 +1,1 @@
+https://github.com/rkh/rbenv-update.git

--- a/share/anyenv/sources/rbenv/rbenv-update-rubies
+++ b/share/anyenv/sources/rbenv/rbenv-update-rubies
@@ -1,0 +1,1 @@
+https://github.com/toy/rbenv-update-rubies.git

--- a/share/anyenv/sources/rbenv/rbenv-use
+++ b/share/anyenv/sources/rbenv/rbenv-use
@@ -1,0 +1,1 @@
+https://github.com/rkh/rbenv-use.git

--- a/share/anyenv/sources/rbenv/rbenv-user-gems
+++ b/share/anyenv/sources/rbenv/rbenv-user-gems
@@ -1,0 +1,1 @@
+https://github.com/mislav/rbenv-user-gems.git

--- a/share/anyenv/sources/rbenv/rbenv-usergems
+++ b/share/anyenv/sources/rbenv/rbenv-usergems
@@ -1,0 +1,1 @@
+https://github.com/andyl/rbenv-usergems.git

--- a/share/anyenv/sources/rbenv/rbenv-whatis
+++ b/share/anyenv/sources/rbenv/rbenv-whatis
@@ -1,0 +1,1 @@
+https://github.com/rkh/rbenv-whatis.git

--- a/share/anyenv/sources/rbenv/rvm-download
+++ b/share/anyenv/sources/rbenv/rvm-download
@@ -1,0 +1,1 @@
+https://github.com/garnieretienne/rvm-download.git

--- a/share/anyenv/sources/sbtenv/sbtenv
+++ b/share/anyenv/sources/sbtenv/sbtenv
@@ -1,0 +1,1 @@
+https://github.com/sbtenv/sbtenv.git

--- a/share/anyenv/sources/scalaenv/scalaenv
+++ b/share/anyenv/sources/scalaenv/scalaenv
@@ -1,0 +1,1 @@
+https://github.com/scalaenv/scalaenv.git

--- a/share/anyenv/sources/swiftenv/swiftenv
+++ b/share/anyenv/sources/swiftenv/swiftenv
@@ -1,0 +1,1 @@
+https://github.com/kylef/swiftenv.git


### PR DESCRIPTION
This PR implements new install/uninstall/update commands.

With these new commands, user can choose which env or plugin to install/uninstall/update. For example:

```
# Install env and plugins
$ anyenv install rbenv rbenv-each rbenv/ruby-build

# Update env and its all installed plugins
$ anyenv update rbenv

# Update env and only 2 plugins
$ anyenv update --without-plugin rbenv rbenv-each rbenv/ruby-build

# Uninstalling env will uninstall all plugins
$ anyenv uninstall rbenv

# To uninstall only 2 plugins
$ anyenv uninstall rbenv-each rbenv/ruby-build
```

This PR introduces a concept called TARGET. A target can be an env or plugin.

The basic form of target is `ENV/PLUGIN`, which means "PLUGIN of ENV". There is also a special case: for `ENV/ENV`, it means the ENV itself. For instance, `rbenv/rbenv` means `rbenv`, **NOT** a plugin named `rbenv`.

You can also use the short form for a target by the following rules:

TARGET (short form) | TARGET (full form) | ENV     | PLUGIN
------------------- | ------------------ | ------- | -----------
foo/bar             | foo/bar            | foo     | bar
foo/foo-bar         | foo/foo-bar        | foo     | foo-bar
foo/baz-bar         | foo/baz-bar        | foo     | baz-bar
foo/foo             | foo/foo            | foo     | foo
foo                 | foo/foo            | foo     | foo
foo-bar             | foo/foo-bar        | foo     | foo-bar
foo-bar-baz         | foo/foo-bar-baz    | foo     | foo-bar-baz
foo/                | foo/foo            | foo     | foo
/bar                | bar/bar            | bar     | bar
/foo-bar            | foo/foo-bar        | foo     | foo-bar
foo-bar/            | foo-bar/foo-bar    | foo-bar | foo-bar

For example:

TARGET (short form) | TARGET (full form) | ENV   | PLUGIN
------------------- | ------------------ | ----- | ----------
rbenv/rbenv-each    | rbenv/rbenv-each   | rbenv | rbenv-each
rbenv               | rbenv/rbenv        | rbenv | rbenv
rbenv-each          | rbenv/rbenv-each   | rbenv | rbenv-each
rbenv/ruby-build    | rbenv/ruby-build   | rbenv | ruby-build
ruby-build          | ruby/ruby-build    | ruby  | ruby-build

Remember, `rbenv/rbenv` means the env `rbenv`, **NOT** a plugin named `rbenv`.

##### How to configure the source url of the target?

When installing a target, anyenv will check the source url in `SOURCE_DIR/ENV/PLUGIN`. Anyenv will try `SOURCE_DIR` in this order:

  - `$XDG_CONFIG_HOME/anyenv/sources` (default: `$HOME/.config/anyenv/sources`)
  - `$ANYENV_ROOT/share/anyenv/sources`

The source is the git url downloaded by anyenv. If you want to use a branch other than the default branch, put

```
<GIT_URL> <GIT_REF>
```

into the source file.

If the source file does not exist, anyenv will try `https://github.com/ENV/PLUGIN.git` with the default branch.

You can also override the url and default branch in the argument, using `TARGET[=URL][@REF]`.  For example:

```
$ anyenv install rbenv=https://github.com/foo/bar.git
$ anyenv install rbenv@baz
$ anyenv install rbenv=https://github.com/foo/bar.git@baz
```

Now we can install an env or plugin even if it has no source file!

-----

Guys, what do you think about it? @riywo

