### PR TITLE
Update URL for sbtenv and scalaenv.

### DIFF
--- a/share/anyenv-install/sbtenv
+++ b/share/anyenv-install/sbtenv
@@ -1,1 +1,1 @@
-install_env "https://github.com/mazgi/sbtenv.git" "master"
+install_env "https://github.com/sbtenv/sbtenv.git" "master"

--- a/share/anyenv-install/scalaenv
+++ b/share/anyenv-install/scalaenv
@@ -1,1 +1,1 @@
-install_env "https://github.com/mazgi/scalaenv.git" "master"
+install_env "https://github.com/scalaenv/scalaenv.git" "master"


### PR DESCRIPTION
These moved to each org:
- https://github.com/sbtenv/sbtenv
- https://github.com/scalaenv/scalaenv