### PR TITLE
Use exenv/exenv repository

### DIFF
--- a/share/anyenv-install/exenv
+++ b/share/anyenv-install/exenv
@@ -1,2 +1,2 @@
-install_env "https://github.com/mururu/exenv.git" "master"
+install_env "https://github.com/exenv/exenv.git" "master"
 install_plugin "elixir-build" "https://github.com/mururu/elixir-build.git" "master"


### PR DESCRIPTION
Mururu's exenv is being no longer maintained, there is a new exenv at [exenv](https://github.com/exenv/exenv.git).

There is still no replacement for Mururu's elixir-build as far as I know.

Related: https://github.com/exenv/exenv/issues/1