### PR TITLE
Change the goenv repository url

### DIFF
--- a/share/anyenv-install/goenv
+++ b/share/anyenv-install/goenv
@@ -1,1 +1,1 @@
-install_env "https://github.com/kaneshin/goenv.git" "master"
+install_env "https://github.com/syndbg/goenv.git" "master"


### PR DESCRIPTION
Hello, everyone.

I'd prefer the repository of goenv because this is maintained by its owner and more popular.
It is also adopted for homebrew.

```zsh:
❯ brew info goenv
goenv: stable 1.4.0, HEAD
Go version management
https://github.com/syndbg/goenv
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/goenv.rb
```

issues: https://github.com/riywo/anyenv/issues/49