### PR TITLE
changed `echo -e` to `printf`

### DIFF
--- a/libexec/anyenv-install
+++ b/libexec/anyenv-install
@@ -113,7 +113,7 @@ definitions() {
 
 echoe() {
   local message="$1"
-  (>&2 echo -e "\e[33m${message}\e[0m")
+  (>&2 printf "\e[33m${message}\e[0m")
 }
 
 initialize_manifest() {

--- a/libexec/anyenv-install
+++ b/libexec/anyenv-install
@@ -113,7 +113,7 @@ definitions() {
 
 echoe() {
   local message="$1"
-  (>&2 printf "\e[33m${message}\e[0m")
+  (>&2 printf "\e[33m%s\e[0m\n" "${message}")
 }
 
 initialize_manifest() {


### PR DESCRIPTION
`echo -e` does not work on MacOS, and escape characters are directory printed like following:

```
\e[33mANYENV_DEFINITION_ROOT(/Users/ytakahashi/.config/anyenv/anyenv-install) doesn't exist. You can initialize it by:\e[0m
\e[33m> anyenv install --init\e[0m
```
