### PR TITLE
Fix typo in anyenv-uninstall.

### DIFF
--- a/libexec/anyenv-uninstall
+++ b/libexec/anyenv-uninstall
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Summary: Uninstall a specific **anv
+# Summary: Uninstall a specific **env
 #
 # Usage: anyenv uninstall [-f|--force] <**env>
 #


### PR DESCRIPTION
I found one typo in anyenv-uninstall, so I fixed it. 