### PR TITLE
Create ANYENV_ENVS_ROOT if not existing

### DIFF
--- a/libexec/anyenv-install
+++ b/libexec/anyenv-install
@@ -65,6 +65,7 @@ install_env() {
     fi
     mv "$PREFIX" "${BUILD_DIR}.prev"
   fi
+  mkdir -p "$ANYENV_ENVS_ROOT"
   mv "${BUILD_DIR}/${ENV_NAME}" "$PREFIX"
 }
 


### PR DESCRIPTION
Fix #74 

With Homebrew installation, there is no `~/.anyenv/envs` directory, which is held by `.gitkeep` with Git installation. With this commit, `anyenv install` automatically create `$ANYENV_ENVS_ROOT` if it doesn't exist.