### PR TITLE
Do not execute init for tfenv

### DIFF
--- a/libexec/anyenv-init
+++ b/libexec/anyenv-init
@@ -140,5 +140,7 @@ for env in $(anyenv-envs); do
     ;;
   esac
 
-  echo "$(${ENV_ROOT}/bin/${env} init - ${no_rehash_arg}${shell})"
+  if [[ ${env} != 'tfenv' ]]; then
+    echo "$(${ENV_ROOT}/bin/${env} init - ${no_rehash_arg}${shell})"
+  fi
 done


### PR DESCRIPTION
## Overview
This PR is just working around for tfenv.

I got the messages below when I executed `anyenv init -`.
```console
> anyenv init -
== I ommited these parts ==
export TFENV_ROOT="/home/mopp/.anyenv/envs/tfenv"
export PATH="/home/mopp/.anyenv/envs/tfenv/bin:$PATH"
no such command 'init'
Usage: tfenv <command> [<options>]

Commands:
   install       Install a specific version of Terraform
   use           Switch a version to use
   uninstall     Uninstall a specific version of Terraform
   list          List all installed versions
   list-remote   List all installable versions
```

anyenv tried to call `*env init` during initialization. However tfenv does not have `init` subcommand.

## Refs
- https://github.com/anyenv/anyenv/issues/79
  - This PR resolves it.
- https://github.com/tfutils/tfenv/issues/53
  - Somebody had discussed the interface of tfenv. But it seems frozen.