### PR TITLE
don't ``xxxenv init`` if it doesn't exists while doing ``anyenv init``

### DIFF
--- a/libexec/anyenv-init
+++ b/libexec/anyenv-init
@@ -140,5 +140,7 @@ for env in $(anyenv-envs); do
     ;;
   esac
 
-  echo "$(${ENV_ROOT}/bin/${env} init - ${no_rehash_arg}${shell})"
+  if { ${ENV_ROOT}/bin/${env} commands | grep -q '^init$' ; } 2> /dev/null  ; then
+    echo "$(${ENV_ROOT}/bin/${env} init - ${no_rehash_arg}${shell})"
+  fi
 done


### PR DESCRIPTION
fix for my issue, [tfenv installation causes trouble. #6](https://github.com/anyenv/anyenv-install/issues/6)