### PR TITLE
Export variables in global scope

### DIFF
--- a/libexec/anyenv-init
+++ b/libexec/anyenv-init
@@ -129,9 +129,9 @@ for env in $(anyenv-envs); do
 
   case "$shell" in
   fish )
-    echo "set -x ${ENV_ROOT_VALUE} \"${ENV_ROOT}\""
+    echo "set -gx ${ENV_ROOT_VALUE} \"${ENV_ROOT}\""
     export ${ENV_ROOT_VALUE}="${ENV_ROOT}"
-    echo "set -x PATH \$PATH \"${ENV_ROOT}/bin\""
+    echo "set -gx PATH \$PATH \"${ENV_ROOT}/bin\""
     ;;
   * )
     echo "export ${ENV_ROOT_VALUE}=\"${ENV_ROOT}\""


### PR DESCRIPTION
Explicitly specify the global scope (`-g` option) when exporting the ENV_ROOT variable.

If the variable is exported without a scope, [it will be local to the function](https://fishshell.com/docs/current/cmds/set.html#:~:text=while%20without%20these%20the%20variable%20will%20be%20local%20to%20the%20function).
Therefore, if the `source (anyenv init - | psub)` is executed in a function, the ENV_ROOT variable will be unexported and unaccessible.

For reference, rbenv and pyenv use global scope as well.
https://github.com/rbenv/rbenv/blob/master/libexec/rbenv-init#L89-L90
https://github.com/pyenv/pyenv/blob/master/libexec/pyenv-init#L89-L90