### PR TITLE
Fix the initialization of pyenv 2.0.0 and higher

### DIFF
--- a/libexec/anyenv-init
+++ b/libexec/anyenv-init
@@ -141,6 +141,18 @@ for env in $(anyenv-envs); do
   esac
 
   if { ${ENV_ROOT}/bin/${env} commands | grep -q '^init$' ; } 2> /dev/null  ; then
-    echo "$(${ENV_ROOT}/bin/${env} init - ${no_rehash_arg}${shell})"
+    case "$env" in
+      pyenv )
+        pyenv_major_version=$(${ENV_ROOT}/bin/${env} --version | cut -d' ' -f2 | cut -d. -f1)
+        if [ $pyenv_major_version -ge 2 ]; then
+          echo "$(${ENV_ROOT}/bin/${env} init --path ${no_rehash_arg}${shell})"
+        else
+          echo "$(${ENV_ROOT}/bin/${env} init - ${no_rehash_arg}${shell})"
+        fi
+        ;;
+      * )
+        echo "$(${ENV_ROOT}/bin/${env} init - ${no_rehash_arg}${shell})"
+        ;;
+    esac
   fi
 done


### PR DESCRIPTION
Recently released pyenv 2.0.0 has introduced [a backward incompatible change](https://github.com/pyenv/pyenv/blob/master/CHANGELOG.md#release-200) in how it initialize itself. As a result, pyenv 2.0.0 or higher installed and initialized via anyenv produces warning messages, which has been reported in #90. This PR will fix the issue. 