### PR TITLE
Fix startup error in fish shell

### DIFF
--- a/libexec/anyenv-init
+++ b/libexec/anyenv-init
@@ -148,9 +148,9 @@ for env in $(anyenv-envs); do
   case ${env} in
     pyenv )
       if [ $(${ENV_ROOT}/bin/${env} --version | env_major_version) -ge 2 ]; then
-        echo "$(${ENV_ROOT}/bin/${env} init --path)" # pyenv 2 requires explicit path setting.
+        echo "$(${ENV_ROOT}/bin/${env} init --path ${shell})" # pyenv 2 requires explicit path setting.
         # To suppress warning, path should be set in this shell context as well.
-        eval "$(${ENV_ROOT}/bin/${env} init --path)"
+        eval "$(${ENV_ROOT}/bin/${env} init --path $(basename $0))"
       fi
       ;;
   esac


### PR DESCRIPTION
I'm getting an error with fish shell and v1.1.3 and can't use anyenv.
Because v1.1.3 lacks arguments to pass to pyenv, errors occur with shells that are incompatible with bash (e.g. fish).

I added the missing shell specification to the current code and fixed it to work.

error message (installed from homebrew):
```
/var/folders/zn/tnjgjcnx35g2bcq6k31p7kp00000gn/T//.psub.bnOpsIqxyJ (line 43): Variables cannot be bracketed. In fish, please use "$PATH".
export PATH="/Users/USERNAME/.anyenv/envs/pyenv/shims:${PATH}"
                                                    ^
from sourcing file /var/folders/zn/tnjgjcnx35g2bcq6k31p7kp00000gn/T//.psub.bnOpsIqxyJ
	called on line 86 of file ~/.config/fish/config.fish
from sourcing file ~/.config/fish/config.fish
	called during startup
source: Error while reading file '/var/folders/zn/tnjgjcnx35g2bcq6k31p7kp00000gn/T//.psub.bnOpsIqxyJ'
```