### PR TITLE
Fix: typo in anyenv-help

### DIFF
--- a/libexec/anyenv-help
+++ b/libexec/anyenv-help
@@ -145,7 +145,7 @@ if [ -z "$1" ] || [ "$1" == "anyenv" ]; then
   echo "Some useful anyenv commands are:"
   print_summaries commands local global shell install uninstall rehash version versions which whence list-modules migrate-modules install-cpanm
   echo
-  echo "See \`anyenv help <command>' for information on a specific command."
+  echo "See 'anyenv help <command>' for information on a specific command."
   echo "For full documentation, see: https://github.com/anyenv/anyenv#readme"
 else
   command="$1"


### PR DESCRIPTION
I found one typo in anyenv-help, so I fixed it.