### PR TITLE
Workaround for tfenv when invoking to anyenv version and versions

### DIFF
--- a/libexec/anyenv-version
+++ b/libexec/anyenv-version
@@ -9,5 +9,9 @@ set -e
 [ -n "$ANYENV_DEBUG" ] && set -x
 
 for env in $(anyenv-envs); do
-  echo "$env: $($env version)"
+  if [ "$env" = "tfenv" ]; then
+    echo "$env: $($env version-name)"
+  else
+    echo "$env: $($env version)"
+  fi
 done

--- a/libexec/anyenv-versions
+++ b/libexec/anyenv-versions
@@ -11,6 +11,8 @@ for env in $(anyenv-envs); do
   echo "$env:"
   if [ "$env" = "erlenv" ]; then
     echo "$($env releases)"
+  elif [ "$env" = "tfenv" ]; then
+    echo "$($env list)"
   else
     echo "$($env versions)"
   fi


### PR DESCRIPTION
Fix https://github.com/anyenv/anyenv/issues/96

`tfenv` uses `version-name` and `list` subcommand instead of `version` and `versions`.