### PR TITLE
[Bug] `pyenv init --path` is no longer needed, and cause problem with other *env

### DIFF
--- a/libexec/anyenv-init
+++ b/libexec/anyenv-init
@@ -145,15 +145,6 @@ for env in $(anyenv-envs); do
   esac
 
   if { ${ENV_ROOT}/bin/${env} commands | grep -q '^init$' ; } 2> /dev/null  ; then
-  case ${env} in
-    pyenv )
-      if [ $(${ENV_ROOT}/bin/${env} --version | env_major_version) -ge 2 ]; then
-        echo "$(${ENV_ROOT}/bin/${env} init --path ${shell})" # pyenv 2 requires explicit path setting.
-        # To suppress warning, path should be set in this shell context as well.
-        eval "$(${ENV_ROOT}/bin/${env} init --path $(basename $0))"
-      fi
-      ;;
-  esac
     echo "$(${ENV_ROOT}/bin/${env} init - ${no_rehash_arg}${shell})"
   fi
 done


### PR DESCRIPTION
According to the pyenv's readme, `pyenv init --path` is a option to setup without shell integration and no longer needed for normal users.

https://github.com/pyenv/pyenv/blob/70b23638f4afca187b0b568ffb7fa53e30477ff3/README.md?plain=1#L275-L276

In the current situation, `pyenv init --path` also causes a problem with anyenv. When logging into zsh, the initialization process stops at pyenv and further (such as rbenv, or sbtenv) are impossible.